### PR TITLE
Updated Slack invite link

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
 		<div id="sub-section">
 			<div class="half">
 				<h3>Join Our Slack Community</h3>
-				<a href="https://join.slack.com/t/openmined/shared_invite/MjE2MzkwNjczMzE0LTE1MDA3NjE4NTQtYTQ3M2I0ODk2Ng" target="_blank" class="button">Collaborate</a>
+				<a href="https://join.slack.com/t/openmined/shared_invite/MjI5MjcwOTk5NjUzLTE1MDMyNTY2MTQtM2RlMmIxNmM5Ng" target="_blank" class="button">Collaborate</a>
 			</div>
 			<div class="half">
 				<h3>Join Our Mailing List</h3>


### PR DESCRIPTION
The Slack invite link is an experimental feature, and has a time limit. Ours was set to expire tomorrow, so I replaced it with an updated link that expires September 19th, 2017, at 8:16 PM. 