### PR TITLE
Slack Invite Link Update

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
 		<div id="sub-section">
 			<div class="half">
 				<h3>Join Our Slack Community</h3>
-				<a href="https://join.slack.com/t/openmined/shared_invite/MjI5MjcwOTk5NjUzLTE1MDMyNTY2MTQtM2RlMmIxNmM5Ng" target="_blank" class="button">Collaborate</a>
+				<a href="https://join.slack.com/t/openmined/shared_invite/enQtMjQzNjExMzkwODgyLTQ5YWNiOWE0OTRkNDhjNDNhOTkwZThjOTJiZWVhOGE1ZGU1Njg0YTRhNWYxZWY1NTZmNWZmY2EyMGI1NjA5N2M" target="_blank" class="button">Collaborate</a>
 			</div>
 			<div class="half">
 				<h3>Join Our Mailing List</h3>


### PR DESCRIPTION
Updated with new, working Slack Invite Link. This one has been upgraded to work indefinitely and never expire, so we shouldn't have to update this again.